### PR TITLE
Fix single type field value 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ composer.phar
 composer.lock
 .DS_Store
 .idea
+*.properties
+nbproject/project.xml

--- a/src/SingleTableInheritanceTrait.php
+++ b/src/SingleTableInheritanceTrait.php
@@ -151,7 +151,7 @@ trait SingleTableInheritanceTrait {
   public function setSingleTableType() {
     $modelClass = get_class($this);
     $classType = property_exists($modelClass, 'singleTableType') ? $modelClass::$singleTableType : null;
-    if ($classType) {
+    if ($classType !== null) {
       if ($this->hasGetMutator(static::$singleTableTypeField)) {
         $this->{static::$singleTableTypeField} = $this->mutateAttribute(static::$singleTableTypeField, $classType);
       } else {
@@ -174,7 +174,7 @@ trait SingleTableInheritanceTrait {
 
     $classType = isset($attributes->$typeField) ? $attributes->$typeField : null;
 
-    if ($classType) {
+    if ($classType !== null) {
       $childTypes = static::getSingleTableTypeMap();
       if (array_key_exists($classType, $childTypes)) {
         $class = $childTypes[$classType];

--- a/tests/Fixtures/MP4Video.php
+++ b/tests/Fixtures/MP4Video.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Nanigans\SingleTableInheritance\Tests\Fixtures;
+
+class MP4Video extends Video {
+
+  protected static $singleTableType = VideoType::MP4;
+}

--- a/tests/Fixtures/Video.php
+++ b/tests/Fixtures/Video.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Nanigans\SingleTableInheritance\Tests\Fixtures;
+
+use Nanigans\SingleTableInheritance\SingleTableInheritanceTrait;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use SebastianBergmann\Exporter\Exception;
+
+class Video extends Eloquent {
+
+  use SingleTableInheritanceTrait;
+
+  protected $table = "videos";
+
+  protected static $singleTableTypeField = 'type';
+
+  protected static $singleTableSubclasses = [
+    'Nanigans\SingleTableInheritance\Tests\Fixtures\MP4Video'
+  ];
+}
+
+class VideoType{
+    const MP4 = 0;
+    const WMV = 1;
+}

--- a/tests/SingleTableInheritanceTraitModelMethodsTest.php
+++ b/tests/SingleTableInheritanceTraitModelMethodsTest.php
@@ -8,6 +8,10 @@ use Nanigans\SingleTableInheritance\Tests\Fixtures\Car;
 use Nanigans\SingleTableInheritance\Tests\Fixtures\MotorVehicle;
 use Nanigans\SingleTableInheritance\Tests\Fixtures\Vehicle;
 
+use Nanigans\SingleTableInheritance\Tests\Fixtures\Video;
+use Nanigans\SingleTableInheritance\Tests\Fixtures\VideoType;
+use Nanigans\SingleTableInheritance\Tests\Fixtures\MP4Video;
+
 /**
  * Class SingleTableInheritanceTraitModelMethodsTest
  *
@@ -101,6 +105,11 @@ class SingleTableInheritanceTraitModelMethodsTest extends TestCase {
     });
 
     $this->assertEquals('car', $car->getAttributes()['discriminator']);
+  }
+  
+  public function testSetSingleTableTypeWithEnum() {
+    $video = new MP4Video();
+    $video->setSingleTableType();
   }
 
   /**
@@ -197,6 +206,16 @@ class SingleTableInheritanceTraitModelMethodsTest extends TestCase {
     $this->assertNull($newVehicle->cruft);
   }
 
+  public function testNewFromBuilderWithEnum() {
+    $video = new Video;
+    $attr = new \stdClass();
+    $attr->type = VideoType::MP4;
+
+    $newVideo = $video->newFromBuilder($attr);
+
+    $this->assertInstanceOf('Nanigans\SingleTableInheritance\Tests\Fixtures\MP4Video', $newVideo);
+  }
+  
   /**
    * @expectedException \Nanigans\SingleTableInheritance\Exceptions\SingleTableInheritanceException
    */


### PR DESCRIPTION
Example when using an int Enum for SingleTableInheritance.
```php
class SingleTableTypes {
    const VARIABLE1 = 0;
    const VARIABLE2 = 1;
    const VARIABLE3 = 2;
    const VARIABLE4= 3;
}
```
When the value was zero it would go trough line 175 on "if($classType)"
when $classType was 0. But was actually valid because its from the database.

Occurred when having this
````php
class SubClass extends BaseClass{
    protected static $singleTableType = SingleTableTypes::VARIABLE1;
}
````
I added the test: 'testNewFromBuilderWithEnum' to test SingleTableInteherence with an int Enum.