### PR TITLE
Typemap refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,18 @@ class Vehicle extends Model
 
   protected static $singleTableTypeField = 'type';
 
-  protected static $singleTableSubclasses = [Car::class, Truck::class];
+  protected static $singleTableSubclasses = [
+    'car'   => Car::class,
+    'truck' => Truck::class
+  ];
 }
 
 class Car extends Vehicle
 {
-  protected static $singleTableType = 'car';
 }
 
 class Truck extends Vehicle
 {
-  protected static $singleTableType = 'truck';
 }
 ```
 
@@ -72,9 +73,6 @@ In the root model set the `protected static` property `$singleTableTypeField` to
 
 ### Define the subclasses
 In the root model and each branch model define the `protected static` property `$singleTableSubclasses` to define which subclasses are part of the classes hierarchy.
-
-### Define the values for class type 
-In each concrete class set the `protected static` property `$singleTableType` to define the string value for this class that will be stored in the `$singleTableTypeField` database column.
 
 
 
@@ -93,27 +91,30 @@ class Vehicle extends Model
 
   protected static $singleTableTypeField = 'type';
 
-  protected static $singleTableSubclasses = [MotorVehicle::class, Bike::class];
+  protected static $singleTableSubclasses = [
+    'motorvehicle' => MotorVehicle::class,
+    'bike'         => Bike::class
+  ];
 }
 
 class MotorVehicle extends Vehicle
 {
-  protected static $singleTableSubclasses = [Car::class, Truck::class];
+  protected static $singleTableSubclasses = [
+    'car'   => Car::class,
+    'truck' => Truck::class
+  ];
 }
 
 class Car extends MotorVehicle
 {
-  protected static $singleTableType = 'car';
 }
 
 class Truck extends MotorVehicle
 {
-  protected static $singleTableType = 'truck';
 }
 
 class Bike extends Vehicle
 {
-  protected static $singleTableType = 'bike';
 }
 ```
 

--- a/tests/Fixtures/Bike.php
+++ b/tests/Fixtures/Bike.php
@@ -4,7 +4,5 @@ namespace Nanigans\SingleTableInheritance\Tests\Fixtures;
 
 class Bike extends Vehicle {
 
-  protected static $singleTableType = 'bike';
-
   protected static $throwInvalidAttributeExceptions = true;
 }

--- a/tests/Fixtures/Car.php
+++ b/tests/Fixtures/Car.php
@@ -4,7 +4,5 @@ namespace Nanigans\SingleTableInheritance\Tests\Fixtures;
 
 class Car extends MotorVehicle {
 
-  protected static $singleTableType = 'car';
-
   protected static $persisted = ['capacity'];
 }

--- a/tests/Fixtures/MotorVehicle.php
+++ b/tests/Fixtures/MotorVehicle.php
@@ -4,12 +4,11 @@ namespace Nanigans\SingleTableInheritance\Tests\Fixtures;
 
 class MotorVehicle extends Vehicle {
 
-  protected static $singleTableType = 'motorvehicle';
-
   protected static $persisted = ['fuel'];
 
   protected static $singleTableSubclasses = [
-    'Nanigans\SingleTableInheritance\Tests\Fixtures\Car',
-    'Nanigans\SingleTableInheritance\Tests\Fixtures\Truck'
+    'car' => 'Nanigans\SingleTableInheritance\Tests\Fixtures\Car',
+    'taxi' => 'Nanigans\SingleTableInheritance\Tests\Fixtures\Taxi',
+    'truck' => 'Nanigans\SingleTableInheritance\Tests\Fixtures\Truck'
   ];
 }

--- a/tests/Fixtures/Taxi.php
+++ b/tests/Fixtures/Taxi.php
@@ -4,8 +4,6 @@ namespace Nanigans\SingleTableInheritance\Tests\Fixtures;
 
 class Taxi extends MotorVehicle {
 
-  protected static $singleTableType = 'taxi';
-
   public function setTypeAttribute($value){
     $this->attributes['type'] = $value;
   }

--- a/tests/Fixtures/Truck.php
+++ b/tests/Fixtures/Truck.php
@@ -2,7 +2,4 @@
 
 namespace Nanigans\SingleTableInheritance\Tests\Fixtures;
 
-class Truck extends MotorVehicle {
-
-  protected static $singleTableType = 'truck';
-}
+class Truck extends MotorVehicle {}

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -5,4 +5,8 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 
 class User extends Eloquent {
 
+  public function vehicles() {
+    return $this->hasMany('Nanigans\SingleTableInheritance\Tests\Fixtures\Vehicle', 'owner_id');
+  }
+
 } 

--- a/tests/Fixtures/Vehicle.php
+++ b/tests/Fixtures/Vehicle.php
@@ -17,8 +17,8 @@ class Vehicle extends Eloquent {
   protected static $persisted = ['color', 'owner_id'];
 
   protected static $singleTableSubclasses = [
-    'Nanigans\SingleTableInheritance\Tests\Fixtures\MotorVehicle',
-    'Nanigans\SingleTableInheritance\Tests\Fixtures\Bike'
+    'motorvehicle' => 'Nanigans\SingleTableInheritance\Tests\Fixtures\MotorVehicle',
+    'bike' => 'Nanigans\SingleTableInheritance\Tests\Fixtures\Bike'
   ];
 
   public function owner() {

--- a/tests/Fixtures/Video.php
+++ b/tests/Fixtures/Video.php
@@ -15,7 +15,7 @@ class Video extends Eloquent {
   protected static $singleTableTypeField = 'type';
 
   protected static $singleTableSubclasses = [
-    'Nanigans\SingleTableInheritance\Tests\Fixtures\MP4Video'
+    VideoType::MP4 => 'Nanigans\SingleTableInheritance\Tests\Fixtures\MP4Video'
   ];
 }
 

--- a/tests/SingleTableInheritanceTraitModelMethodsTest.php
+++ b/tests/SingleTableInheritanceTraitModelMethodsTest.php
@@ -79,13 +79,13 @@ class SingleTableInheritanceTraitModelMethodsTest extends TestCase {
   // getSingleTableTypes
 
   public function testGetSingleTableTypesOfRoot() {
-    $types = ['motorvehicle', 'car', 'truck', 'bike'];
+    $types = ['motorvehicle', 'bike', 'car', 'taxi', 'truck'];
 
     $this->assertEquals($types, (new Vehicle)->getSingleTableTypes());
   }
 
   public function testGetTypeMapOfChild() {
-    $types = ['motorvehicle', 'car', 'truck'];
+    $types = ['motorvehicle', 'car', 'taxi', 'truck'];
 
     $this->assertEquals($types, (new MotorVehicle())->getSingleTableTypes());
   }

--- a/tests/SingleTableInheritanceTraitQueryTest.php
+++ b/tests/SingleTableInheritanceTraitQueryTest.php
@@ -4,6 +4,7 @@ namespace Nanigans\SingleTableInheritance\Tests;
 
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
+use Nanigans\SingleTableInheritance\Tests\Fixtures\User;
 use Nanigans\SingleTableInheritance\Tests\Fixtures\Bike;
 use Nanigans\SingleTableInheritance\Tests\Fixtures\Car;
 use Nanigans\SingleTableInheritance\Tests\Fixtures\MotorVehicle;
@@ -204,5 +205,19 @@ class SingleTableInheritanceTraitQueryTest extends TestCase {
     $dbCar = Vehicle::where('color', 'red')->first();
     $dbCar->color = 'green';
     $this->assertTrue($dbCar->save()); // if the scope doesn't remove bindings this save will throw an exception.
+  }
+
+  public function testTypedModelLoadedFromRelationship() {
+    $user = new User();
+    $user->name = 'Vehicle Owner';
+    $user->save();
+
+    $user->vehicles()->save(new Car());
+    $user->vehicles()->save(new Bike());
+
+    $user = User::with('vehicles')->where('id', $user->id)->first();
+    $this->assertCount(2, $user->vehicles);
+    $this->assertInstanceOf('Nanigans\SingleTableInheritance\Tests\Fixtures\Car', $user->vehicles[0]);
+    $this->assertInstanceOf('Nanigans\SingleTableInheritance\Tests\Fixtures\Bike', $user->vehicles[1]);
   }
 } 

--- a/tests/SingleTableInheritanceTraitStaticMethodsTest.php
+++ b/tests/SingleTableInheritanceTraitStaticMethodsTest.php
@@ -24,7 +24,7 @@ class SingleTableInheritanceTraitStaticMethodsTest extends TestCase {
       'car'          => 'Nanigans\SingleTableInheritance\Tests\Fixtures\Car',
       'truck'        => 'Nanigans\SingleTableInheritance\Tests\Fixtures\Truck',
       'bike'         => 'Nanigans\SingleTableInheritance\Tests\Fixtures\Bike',
-
+      'taxi'         => 'Nanigans\SingleTableInheritance\Tests\Fixtures\Taxi',
     ];
 
     $this->assertEquals($expectedSubclassTypes, Vehicle::getSingleTableTypeMap());
@@ -35,6 +35,7 @@ class SingleTableInheritanceTraitStaticMethodsTest extends TestCase {
       'motorvehicle' => 'Nanigans\SingleTableInheritance\Tests\Fixtures\MotorVehicle',
       'car'          => 'Nanigans\SingleTableInheritance\Tests\Fixtures\Car',
       'truck'        => 'Nanigans\SingleTableInheritance\Tests\Fixtures\Truck',
+      'taxi'         => 'Nanigans\SingleTableInheritance\Tests\Fixtures\Taxi',
     ];
 
     $this->assertEquals($expectedSubclassTypes, MotorVehicle::getSingleTableTypeMap());


### PR DESCRIPTION
Refactors how the type map is built to fix #20.  The type names are now defined as keys on the subclass array rather than in the model.

All of the tests pass with some slightly refactored to handle the change.

This is a breaking change.
