### PR TITLE
Update for Laravel 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
   ],
   "require": {
     "php": ">= 5.5.9",
-    "illuminate/database": "5.2.*",
-    "illuminate/support": "5.2.*"
+    "illuminate/database": "5.3.*",
+    "illuminate/support": "5.3.*"
   },
   "require-dev": {
     "mockery/mockery": "0.9.*",

--- a/src/SingleTableInheritanceScope.php
+++ b/src/SingleTableInheritanceScope.php
@@ -4,9 +4,9 @@ namespace Nanigans\SingleTableInheritance;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\ScopeInterface;
+use Illuminate\Database\Eloquent\Scope;
 
-class SingleTableInheritanceScope implements ScopeInterface {
+class SingleTableInheritanceScope implements Scope {
 
   /**
    * Apply the scope to a given Eloquent query builder.


### PR DESCRIPTION
Changed the now deprecated ScopeInterface to Scope, and updated the dependency to 5.3 in composer.json