### PR TITLE
New from builder bugfix

### DIFF
--- a/src/SingleTableInheritanceTrait.php
+++ b/src/SingleTableInheritanceTrait.php
@@ -171,15 +171,16 @@ trait SingleTableInheritanceTrait {
    */
   public function newFromBuilder($attributes = array(), $connection = null) {
     $typeField = static::$singleTableTypeField;
+    $attributes = (array) $attributes;
 
-    $classType = isset($attributes->$typeField) ? $attributes->$typeField : null;
+    $classType = array_key_exists($typeField, $attributes) ? $attributes[$typeField] : null;
 
     if ($classType !== null) {
       $childTypes = static::getSingleTableTypeMap();
       if (array_key_exists($classType, $childTypes)) {
         $class = $childTypes[$classType];
         $instance = (new $class)->newInstance([], true);
-        $instance->setFilteredAttributes((array) $attributes);
+        $instance->setFilteredAttributes($attributes);
         $instance->setConnection($connection ?: $this->connection);
         return $instance;
       } else {

--- a/tests/SingleTableInheritanceTraitModelMethodsTest.php
+++ b/tests/SingleTableInheritanceTraitModelMethodsTest.php
@@ -190,6 +190,13 @@ class SingleTableInheritanceTraitModelMethodsTest extends TestCase {
 
   // newFromBuilder
 
+  public function testNewFromBuilderWithArray() {
+    $vehicle = new Vehicle();
+    $newVehicle = $vehicle->newFromBuilder([
+      'type' => 'car'
+    ]);
+  }
+
   public function testNewFromBuilder() {
     $vehicle = new Vehicle;
     $attr = new \stdClass();

--- a/tests/SingleTableInheritanceTraitModelMethodsTest.php
+++ b/tests/SingleTableInheritanceTraitModelMethodsTest.php
@@ -195,6 +195,8 @@ class SingleTableInheritanceTraitModelMethodsTest extends TestCase {
     $newVehicle = $vehicle->newFromBuilder([
       'type' => 'car'
     ]);
+
+    $this->assertInstanceOf('Nanigans\SingleTableInheritance\Tests\Fixtures\Car', $newVehicle);
   }
 
   public function testNewFromBuilder() {

--- a/tests/SingleTableInheritanceTraitModelMethodsTest.php
+++ b/tests/SingleTableInheritanceTraitModelMethodsTest.php
@@ -199,13 +199,24 @@ class SingleTableInheritanceTraitModelMethodsTest extends TestCase {
     $this->assertInstanceOf('Nanigans\SingleTableInheritance\Tests\Fixtures\Car', $newVehicle);
   }
 
-  public function testNewFromBuilder() {
+  public function testNewFromBuilderWithObject() {
     $vehicle = new Vehicle;
     $attr = new \stdClass();
     $attr->type = 'car';
-    $attr->fuel = 'diesel';
-    $attr->color = 'red';
-    $attr->cruft = 'junk';
+
+    $newVehicle = $vehicle->newFromBuilder($attr);
+
+    $this->assertInstanceOf('Nanigans\SingleTableInheritance\Tests\Fixtures\Car', $newVehicle);
+  }
+
+  public function testNewFromBuilder() {
+    $vehicle = new Vehicle;
+    $attr = [
+      'fuel' => 'diesel',
+      'color' => 'red',
+      'cruft' => 'junk',
+      'type' => 'car'
+    ];
 
     $newVehicle = $vehicle->newFromBuilder($attr);
 
@@ -217,8 +228,9 @@ class SingleTableInheritanceTraitModelMethodsTest extends TestCase {
 
   public function testNewFromBuilderWithEnum() {
     $video = new Video;
-    $attr = new \stdClass();
-    $attr->type = VideoType::MP4;
+    $attr = [
+      'type' => VideoType::MP4
+    ];
 
     $newVideo = $video->newFromBuilder($attr);
 
@@ -230,8 +242,7 @@ class SingleTableInheritanceTraitModelMethodsTest extends TestCase {
    */
   public function testNewFromBuilderThrowsIfClassTypeIsUndefined() {
     $vehicle = new Vehicle;
-    $attr = new \stdClass();
-    $vehicle->newFromBuilder($attr);
+    $vehicle->newFromBuilder();
   }
 
   /**
@@ -239,8 +250,9 @@ class SingleTableInheritanceTraitModelMethodsTest extends TestCase {
    */
   public function testNewFromBuilderThrowsIfClassTypeIsNull() {
     $vehicle = new Vehicle;
-    $attr = new \stdClass();
-    $attr->type = null;
+    $attr = [
+      'type' => null
+    ];
     $vehicle->newFromBuilder($attr);
   }
 
@@ -249,8 +261,9 @@ class SingleTableInheritanceTraitModelMethodsTest extends TestCase {
    */
   public function testNewFromBuilderThrowsIfClassTypeIsUnrecognized() {
     $vehicle = new Vehicle;
-    $attr = new \stdClass();
-    $attr->type = 'junk';
+    $attr = [
+      'type' => 'junk'
+    ];
     $vehicle->newFromBuilder($attr);
   }
 }


### PR DESCRIPTION
This fixes a bug where if you were to use `newFromBuilder` with an array (as it is designed), an exception will be thrown saying that you cannot use newFromBuilder without a value for the typeField, despite actually having a value for that typeField. The problem was that the overwritten method for newFromBuilder was operating on an object instead of an array. To ensure that this is backwards compatible for cases that use newFromBuilder with an object, I updated the override to cast attributes to an array first. This allows all old tests and the new test to pass. You can see the bug illustrated if you run tests without the committed bugfix. 