### PR TITLE
Compatibility with Laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
   ],
   "require": {
     "php": ">= 5.5.9",
-    "illuminate/database": "5.2.*|5.3.*|5.4.*|5.5.*",
-    "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*"
+    "illuminate/database": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
+    "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*"
   },
   "require-dev": {
     "mockery/mockery": "0.9.*",

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
     "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*"
   },
   "require-dev": {
-    "mockery/mockery": "0.9.*",
-    "phpunit/phpunit": "~4.8|~5.2|~6.0",
-    "orchestra/testbench": "3.2.*|3.5.*",
-    "orchestra/database": "3.2.*|3.5.*"
+    "mockery/mockery": "0.9.*|~1.0",
+    "phpunit/phpunit": "~4.8|~5.2|~6.0|~7.0",
+    "orchestra/testbench": "3.2.*|3.5.*|3.6.*",
+    "orchestra/database": "3.2.*|3.5.*|3.6.*"
   },
   "autoload": {
     "psr-4": {
@@ -35,5 +35,6 @@
         "dev-master": "0.9.x-dev"
     }
   },
-  "minimum-stability": "stable"
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }


### PR DESCRIPTION
Been using my own fork with Laravel 5.6 now for a few days without problems. Had to set minimum-stability to dev, tho, cause orchestra/database hasn't been tagged yet.