### PR TITLE
getSingleTableTypes can be static

### DIFF
--- a/src/SingleTableInheritanceTrait.php
+++ b/src/SingleTableInheritanceTrait.php
@@ -140,7 +140,7 @@ trait SingleTableInheritanceTrait {
    * Get the list of all types in the hierarchy.
    * @return array the list of type strings
    */
-  public function getSingleTableTypes() {
+  public static function getSingleTableTypes() {
     return array_keys(static::getSingleTableTypeMap());
   }
 


### PR DESCRIPTION
I wanted to call getSingleTableTypes statically and was surprised I couldn't. It's only using static data and all the tests pass.

Thanks!