### PR TITLE
refactored trait to fix getSingleTableTypeMap method returning wrong class if integer key is used

### DIFF
--- a/src/SingleTableInheritanceTrait.php
+++ b/src/SingleTableInheritanceTrait.php
@@ -62,7 +62,7 @@ trait SingleTableInheritanceTrait {
       // prevent infinite recursion if the singleTableSubclasses is inherited
       if (!in_array($calledClass, $subclasses)) {
         foreach ($subclasses as $subclass) {
-          $typeMap = array_merge($typeMap, $subclass::getSingleTableTypeMap());
+          $typeMap = $typeMap + $subclass::getSingleTableTypeMap();
         }
       }
     }

--- a/tests/Fixtures/Video.php
+++ b/tests/Fixtures/Video.php
@@ -15,11 +15,12 @@ class Video extends Eloquent {
   protected static $singleTableTypeField = 'type';
 
   protected static $singleTableSubclasses = [
-    'Nanigans\SingleTableInheritance\Tests\Fixtures\MP4Video'
+    'Nanigans\SingleTableInheritance\Tests\Fixtures\MP4Video',
+    'Nanigans\SingleTableInheritance\Tests\Fixtures\WMVVideo',
   ];
 }
 
 class VideoType{
-    const MP4 = 0;
-    const WMV = 1;
+  const MP4 = 1;
+  const WMV = 2;
 }

--- a/tests/Fixtures/WMVVideo.php
+++ b/tests/Fixtures/WMVVideo.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Nanigans\SingleTableInheritance\Tests\Fixtures;
+
+class WMVVideo extends Video {
+
+  protected static $singleTableType = VideoType::WMV;
+}

--- a/tests/SingleTableInheritanceTraitStaticMethodsTest.php
+++ b/tests/SingleTableInheritanceTraitStaticMethodsTest.php
@@ -2,10 +2,10 @@
 
 namespace Nanigans\SingleTableInheritance\Tests;
 
-use Illuminate\Support\Facades\DB;
 use Nanigans\SingleTableInheritance\Tests\Fixtures\Car;
 use Nanigans\SingleTableInheritance\Tests\Fixtures\MotorVehicle;
 use Nanigans\SingleTableInheritance\Tests\Fixtures\Vehicle;
+use Nanigans\SingleTableInheritance\Tests\Fixtures\Video;
 
 /**
  * Class SingleTableInheritanceTraitStaticMethodsTest
@@ -47,6 +47,15 @@ class SingleTableInheritanceTraitStaticMethodsTest extends TestCase {
     ];
 
     $this->assertEquals($expectedSubclassTypes, Car::getSingleTableTypeMap());
+  }
+
+  public function testGetTypeMapOfRootHavingIntegerType() {
+    $expectedSubclassTypes = [
+      1 => 'Nanigans\SingleTableInheritance\Tests\Fixtures\MP4Video',
+      2 => 'Nanigans\SingleTableInheritance\Tests\Fixtures\WMVVideo',
+    ];
+
+    $this->assertEquals($expectedSubclassTypes, Video::getSingleTableTypeMap());
   }
 
   // getAllPersistedAttributes


### PR DESCRIPTION
using array_merge, numeric keys will be renumbered.

so if I have keys 1,2 they will be renumbered to 0,1 and hence the result from getSingleTableTypeMap() method is not correct.