### PR TITLE
Added support for Laravel 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
   ],
   "require": {
     "php": ">= 5.5.9",
-    "illuminate/database": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
-    "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*"
+    "illuminate/database": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
+    "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*"
   },
   "require-dev": {
     "mockery/mockery": "0.9.*|~1.0",


### PR DESCRIPTION
Updated `composer.json` to allow version 5.7 of `laravel/framework`. Haven't explicitly tested it in a fresh Laravel project yet, but `phpunit` returns no errors.