### PR TITLE
Feature allow create from base model

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.php]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ composer.phar
 composer.lock
 .DS_Store
 .idea
+.phpunit.result.cache
 *.properties
 nbproject/project.xml

--- a/src/SingleTableInheritanceTrait.php
+++ b/src/SingleTableInheritanceTrait.php
@@ -162,7 +162,7 @@ trait SingleTableInheritanceTrait {
       } else {
         $this->{static::$singleTableTypeField} = $classType;
       }
-    } else {
+    } elseif (!isset($this->{static::$singleTableTypeField})) {
       // We'd like to be able to declare non-leaf classes in the hierarchy as abstract so they can't be instantiated and saved.
       // However, Eloquent expects to instantiate classes at various points. Therefore throw an exception if we try to save
       // and instance that doesn't have a type.

--- a/tests/Fixtures/Vehicle.php
+++ b/tests/Fixtures/Vehicle.php
@@ -9,15 +9,21 @@ class Vehicle extends Eloquent {
 
   use SingleTableInheritanceTrait;
 
+  public const TYPE_FIELD = 'type';
+
   protected $table = "vehicles";
 
-  protected static $singleTableTypeField = 'type';
+  protected static $singleTableTypeField = self::TYPE_FIELD;
 
   protected static $persisted = ['color', 'owner_id'];
 
   protected static $singleTableSubclasses = [
     'Nanigans\SingleTableInheritance\Tests\Fixtures\MotorVehicle',
     'Nanigans\SingleTableInheritance\Tests\Fixtures\Bike'
+  ];
+
+  protected $fillable = [
+    self::TYPE_FIELD,
   ];
 
   public function owner() {

--- a/tests/SingleTableInheritanceTraitCreateFromBaseModel.php
+++ b/tests/SingleTableInheritanceTraitCreateFromBaseModel.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Nanigans\SingleTableInheritance\Tests;
+
+use Illuminate\Support\Facades\DB;
+use Nanigans\SingleTableInheritance\Tests\Fixtures\Vehicle;
+
+final class SingleTableInheritanceTraitCreateFromBaseModel extends TestCase
+{
+  private const EXPECTED_TYPE = 'truck';
+
+  public function testHasCorrectTypeAfterCreation(): void
+  {
+    Vehicle::create([Vehicle::TYPE_FIELD => self::EXPECTED_TYPE]);
+    $actualType = DB::table('vehicles')->first()->{Vehicle::TYPE_FIELD} ?? '';
+    self::assertEquals(self::EXPECTED_TYPE, $actualType);
+  }
+}


### PR DESCRIPTION
Hi! :)

Please consider adding this as a new feature. 
This allows to create child models using base models `create` method.
My use case for this is when using DB seeders.

E.g.:
```php
foreach (['car', 'truck'] as $type) {
    Vehicle::create(compact('type'));
}
```