### PR TITLE
Create a test case for mutated attributes

### DIFF
--- a/tests/Fixtures/Book.php
+++ b/tests/Fixtures/Book.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Nanigans\SingleTableInheritance\Tests\Fixtures;
+
+
+class Book extends Publication
+{
+    protected static $singleTableType = 'book';
+}

--- a/tests/Fixtures/Publication.php
+++ b/tests/Fixtures/Publication.php
@@ -1,0 +1,56 @@
+<?php
+namespace Nanigans\SingleTableInheritance\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Concerns\HasEvents;
+use Nanigans\SingleTableInheritance\Tests\Fixtures\UsesUuid;
+use Nanigans\SingleTableInheritance\SingleTableInheritanceTrait;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+/**
+* @property string                 name
+* @property Publisher              publisher
+*/
+class Publication extends Eloquent
+{
+    use SingleTableInheritanceTrait;
+    protected static $singleTableTypeField = 'type';
+
+    protected $table = "publications";
+
+    protected static $singleTableSubclasses = [
+        'Nanigans\SingleTableInheritance\Tests\Fixtures\Book',
+    ];
+
+    /**
+     * @var array
+     */
+    protected $fillable = [
+        'publisher_id',
+        'type',
+        'name'
+    ];
+
+    protected $attributes = [
+        'publisher_id' => '',
+        'name' => ''
+    ];
+    protected $casts = [
+        'name' => 'string',
+        'publisher_id' => 'string',
+        ];
+
+    public function publisher()
+    {
+        return $this->belongsTo(
+            Publisher::class,
+            'publisher_id',
+            'id'
+        );
+    }
+
+    public function setPublisherIdAttribute($value)
+    {
+        $this->attributes['publisher_id'] = $value . "test";
+    }
+
+}

--- a/tests/Fixtures/Publisher.php
+++ b/tests/Fixtures/Publisher.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Nanigans\SingleTableInheritance\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Concerns\HasEvents;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+/**
+ * @property string name
+ */
+class Publisher extends Eloquent
+{
+    protected $table = "publishers";
+
+    /**
+     * @var array
+     */
+    protected $fillable = [
+        'name'
+    ];
+
+}

--- a/tests/SingleTableInheritanceMutatedPropertyTest.php
+++ b/tests/SingleTableInheritanceMutatedPropertyTest.php
@@ -1,0 +1,46 @@
+<?php
+
+
+namespace Nanigans\SingleTableInheritance\Tests;
+
+use Nanigans\SingleTableInheritance\Tests\Fixtures\Book;
+use Nanigans\SingleTableInheritance\Tests\Fixtures\Publication;
+use Nanigans\SingleTableInheritance\Tests\Fixtures\Publisher;
+
+class SingleTableInheritanceMutatedPropertyTest extends TestCase
+{
+
+    public function testMutatedPropertyDirect() {
+        $publisher_attr = ['name' => 'MyPublishingHouse'];
+        $publisher = new Publisher($publisher_attr);
+        $publisher->save();
+
+        $publication_attr = ['name' => 'MyBook', 'publisher_id' => $publisher->id, 'type' => 'book'];
+        $book = new Book($publication_attr);
+        $book->save();
+        $publisher_id = $book->getAttributeValue('publisher_id');
+
+        $expected = $publisher->id . "test";
+
+        $this->assertEquals($expected, $publisher_id);
+
+    }
+
+    public function testMutatedPropertyFromBuilder() {
+        $publisher_attr = ['name' => 'MyPublishingHouse'];
+        $publisher = new Publisher($publisher_attr);
+        $publisher->save();
+
+        $publication_attr = ['name' => 'MyBook', 'publisher_id' => $publisher->id, 'type' => 'book'];
+        $parent = new Publication;
+        $book = $parent->newFromBuilder($publication_attr);
+        $book->save();
+        $publisher_id = $book->getAttributeValue('publisher_id');
+        $expected = $publisher->id . "test";
+
+
+        $this->assertEquals($expected, $publisher_id);
+
+    }
+
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,6 +28,9 @@ abstract class TestCase extends OrchestraTestCase {
       'Nanigans\SingleTableInheritance\Tests\Fixtures\MotorVehicle',
       'Nanigans\SingleTableInheritance\Tests\Fixtures\Car',
       'Nanigans\SingleTableInheritance\Tests\Fixtures\Truck',
+      'Nanigans\SingleTableInheritance\Tests\Fixtures\Publication',
+      'Nanigans\SingleTableInheritance\Tests\Fixtures\Publisher',
+      'Nanigans\SingleTableInheritance\Tests\Fixtures\Book',
       'Nanigans\SingleTableInheritance\Tests\Fixtures\Bike'
     ];
     // Reset each model event listeners.

--- a/tests/migrations/2021_09_03_210504_create_publication_table.php
+++ b/tests/migrations/2021_09_03_210504_create_publication_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePublicationTable extends Migration {
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('publications', function ($table){
+            $table->increments('id');
+            $table->string('name');
+            $table->string('publisher_id');
+            $table->string('type');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('publications');
+    }
+
+}

--- a/tests/migrations/2021_09_03_210504_create_publishers_table.php
+++ b/tests/migrations/2021_09_03_210504_create_publishers_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePublishersTable extends Migration {
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('publishers', function ($table){
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('publishers');
+    }
+
+}


### PR DESCRIPTION
These changes show a failure test case for `newFromBuilder` when an object has mutated attributes.

This basically comes from using the `setRawAttributesFunction` [here](https://github.com/jonspalmer/single-table-inheritance/blob/main/src/SingleTableInheritanceTrait.php#L232) when filtering out attributes.

If you used a loop for setting attributes, I think this could be fixed. 

Related to #70 