### PR TITLE
Fix: Unable to refresh a collection containing mixed types

### DIFF
--- a/src/SingleInheritanceBuilderTrait.php
+++ b/src/SingleInheritanceBuilderTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Nanigans\SingleTableInheritance;
+
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
+use Nanigans\SingleTableInheritance\Contracts\SingleTableInheritanceBuilder;
+
+trait SingleInheritanceBuilderTrait
+{
+    /**
+     * Returns a fresh instance of the model at the root of the inheritance-tree as defined by
+     * the Builder's `singleInheritanceRootModelClass` property.
+     * @return Model
+     */
+    protected function newSingleInheritanceRootModel(): Model
+    {
+        $property = 'singleInheritanceRootModelClass';
+        if (!property_exists($this, $property)) {
+            throw new \RuntimeException(sprintf(
+                '%s must declare a string property named %s',
+                get_called_class(),
+                $property
+            ));
+        }
+
+        $className = $this->$property;
+        return new $className();
+    }
+
+    /**
+     * This makes it so that polymorphic collections can be constructed properly.
+     *
+     * @param  array|string  $columns
+     * @return Model[]|static[]
+     */
+    public function getModels($columns = ['*'])
+    {
+        /*
+         * The problem stems from Laravel using the first element in the collection to hydrate the rest of the records
+         * into Eloquent models. Thus, if any of the subsequent records do is of a type that does not inherit
+         * from that of the first element, then it fails.
+         *
+         * If we use an instance of the root model of the
+         * inheritance tree, then we can properly hydrate records into polymorphic models.
+         */
+        $rootModel = $this->newSingleInheritanceRootModel();
+        return $rootModel->hydrate(
+            $this->query->get($columns)->all()
+        )->all();
+    }
+}

--- a/tests/Fixtures/Vehicle.php
+++ b/tests/Fixtures/Vehicle.php
@@ -66,4 +66,9 @@ class Vehicle extends Eloquent {
   public function setTable($table) {
     $this->table = $table;
   }
+
+  public function newEloquentBuilder($query)
+  {
+      return new VehicleBuilder($query);
+  }
 }

--- a/tests/Fixtures/VehicleBuilder.php
+++ b/tests/Fixtures/VehicleBuilder.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Nanigans\SingleTableInheritance\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Builder;
+use Nanigans\SingleTableInheritance\SingleInheritanceBuilderTrait;
+
+class VehicleBuilder extends Builder
+{
+   use SingleInheritanceBuilderTrait;
+
+   protected $singleInheritanceRootModelClass = Vehicle::class;
+}

--- a/tests/SingleTableInheritanceTraitCollectionTest.php
+++ b/tests/SingleTableInheritanceTraitCollectionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Nanigans\SingleTableInheritance\Tests;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Nanigans\SingleTableInheritance\Exceptions\SingleTableInheritanceException;
+use Nanigans\SingleTableInheritance\Tests\Fixtures\User;
+use Nanigans\SingleTableInheritance\Tests\Fixtures\Bike;
+use Nanigans\SingleTableInheritance\Tests\Fixtures\Car;
+use Nanigans\SingleTableInheritance\Tests\Fixtures\MotorVehicle;
+use Nanigans\SingleTableInheritance\Tests\Fixtures\Truck;
+use Nanigans\SingleTableInheritance\Tests\Fixtures\Vehicle;
+
+/**
+ * Class SingleTableInheritanceTraitQueryTest
+ *
+ * A set of tests for the behavior of Eloquent collections that are polymorphic.
+ *
+ * @package Nanigans\SingleTableInheritance\Tests
+ */
+class SingleTableInheritanceTraitCollectionTest extends TestCase {
+
+  public function testRefresh() {
+    (new MotorVehicle())->save();
+    (new Car())->save();
+    (new Truck())->save();
+    (new Truck())->save();
+    (new Bike())->save();
+
+    $results = Vehicle::all();
+
+    $this->assertEquals(5, count($results));
+
+    $this->assertInstanceOf('Nanigans\SingleTableInheritance\Tests\Fixtures\MotorVehicle', $results[0]);
+    $this->assertInstanceOf('Nanigans\SingleTableInheritance\Tests\Fixtures\Car',          $results[1]);
+    $this->assertInstanceOf('Nanigans\SingleTableInheritance\Tests\Fixtures\Truck',        $results[2]);
+    $this->assertInstanceOf('Nanigans\SingleTableInheritance\Tests\Fixtures\Truck',        $results[3]);
+    $this->assertInstanceOf('Nanigans\SingleTableInheritance\Tests\Fixtures\Bike',         $results[4]);
+
+    $results = $results->fresh();
+
+    $this->assertInstanceOf('Nanigans\SingleTableInheritance\Tests\Fixtures\MotorVehicle', $results[0]);
+    $this->assertInstanceOf('Nanigans\SingleTableInheritance\Tests\Fixtures\Car',          $results[1]);
+    $this->assertInstanceOf('Nanigans\SingleTableInheritance\Tests\Fixtures\Truck',        $results[2]);
+    $this->assertInstanceOf('Nanigans\SingleTableInheritance\Tests\Fixtures\Truck',        $results[3]);
+    $this->assertInstanceOf('Nanigans\SingleTableInheritance\Tests\Fixtures\Bike',         $results[4]);
+  }
+}


### PR DESCRIPTION
Ran into an issue when trying to refresh an Eloquent collection that contains a mixture of types. The original implementation uses the first element of the collection to hydrate the rest of the records' array into fresh models, and unfortunately that means that will fail eventually.

This is the result of a failing test I wrote to illustrate this:

```
1) Nanigans\SingleTableInheritance\Tests\SingleTableInheritanceTraitCollectionTest::testRefresh
Nanigans\SingleTableInheritance\Exceptions\SingleTableInheritanceException: Cannot construct newFromBuilder for unrecognized type=bike

/Users/bezalel/Development/single-table-inheritance/src/SingleTableInheritanceTrait.php:195
/Users/bezalel/Development/single-table-inheritance/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:363
/Users/bezalel/Development/single-table-inheritance/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:362
/Users/bezalel/Development/single-table-inheritance/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php:23
/Users/bezalel/Development/single-table-inheritance/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:2132
/Users/bezalel/Development/single-table-inheritance/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:625
/Users/bezalel/Development/single-table-inheritance/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:609
/Users/bezalel/Development/single-table-inheritance/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Collection.php:391
/Users/bezalel/Development/single-table-inheritance/tests/SingleTableInheritanceTraitCollectionTest.php:41
```

---

I propose introducing this trait that can be used in a custom Eloquent builder attached to models that use single-table inheritance. See what's done in the `Vehicle` model fixture and the `VehicleBuilder` class.